### PR TITLE
Update to Flutter beta channel

### DIFF
--- a/performance/example/pubspec.lock
+++ b/performance/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -42,14 +42,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -85,7 +85,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   lints:
     dependency: transitive
     description:
@@ -99,7 +99,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -113,14 +120,14 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   performance:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.1"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -139,7 +146,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -174,14 +181,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   url_launcher:
     dependency: "direct main"
     description:
@@ -237,7 +237,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.5.0"

--- a/performance/lib/src/overlay.dart
+++ b/performance/lib/src/overlay.dart
@@ -220,12 +220,12 @@ class _CustomPerformanceOverlayState extends State<_CustomPerformanceOverlay> {
   @override
   void initState() {
     super.initState();
-    SchedulerBinding.instance!.addTimingsCallback(_timingsCallback);
+    SchedulerBinding.instance.addTimingsCallback(_timingsCallback);
   }
 
   @override
   void dispose() {
-    SchedulerBinding.instance!.removeTimingsCallback(_timingsCallback);
+    SchedulerBinding.instance.removeTimingsCallback(_timingsCallback);
     super.dispose();
   }
 
@@ -248,7 +248,7 @@ class _CustomPerformanceOverlayState extends State<_CustomPerformanceOverlay> {
     // Furthermore, this prevents indefinite rebuilds on desktop as setting
     // state after the timings callback triggers another timings callback but
     // doing so in a post frame callback somehow does not.
-    SchedulerBinding.instance!.addPostFrameCallback((timeStamp) {
+    SchedulerBinding.instance.addPostFrameCallback((timeStamp) {
       if (!mounted) return;
       setState(() {
         _samples = combinedSamples.sublist(max(

--- a/performance/pubspec.lock
+++ b/performance/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -42,14 +42,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,7 +80,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -94,7 +101,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -106,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -141,21 +148,13 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=2.17.0-0 <3.0.0"

--- a/performance/pubspec.yaml
+++ b/performance/pubspec.yaml
@@ -1,11 +1,10 @@
 name: performance
 description: Performance overlay package for Flutter apps that works on web.
-version: 0.1.0+1
+version: 0.1.1
 homepage: https://github.com/creativecreatorormaybenot/performance/tree/main/performance
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
-  flutter: '>=1.17.0'
+  sdk: '>=2.17.0-0 <3.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
SchedulerBinding.instance is now non-nullable, so the [unnecessary_non_null_assertion](https://dart.dev/tools/diagnostic-messages#unnecessary_non_null_assertion) diagnostic is triggered. 

To fix, I ran "dart fix --apply", since this diagnostic can be fixed automatically.

Increases the patch version of this package, since the API isn't changing.